### PR TITLE
Fix image variant validation

### DIFF
--- a/app/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/controllers/spree/admin/images_controller_decorator.rb
@@ -10,6 +10,7 @@ Spree::Admin::ImagesController.class_eval do
     end
 
     def set_variants
+      @image.validate_variant_presence = true
       @image.variant_ids = viewable_ids
     end
 

--- a/app/models/spree/image_decorator.rb
+++ b/app/models/spree/image_decorator.rb
@@ -1,12 +1,14 @@
 Spree::Image.class_eval do
-  attr_accessor :viewable_ids
+  attr_accessor :viewable_ids, :validate_variant_presence
 
   has_many :variant_images, class_name: '::Spree::VariantImage'
   has_many :variants, through: :variant_images
 
   validates :variants,
     length: { minimum: 1,
-              message: 'must have at least one selection' }
+              message: 'must have at least one selection',
+              if: -> { validate_variant_presence }
+            }
 
   def variant_html_classes
     variant_ids.map { |variant| "tmb-#{variant}"}.join(" ")

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,7 +1,7 @@
 Spree::Product.class_eval do
-  has_many :nonuniq_variant_images, -> { order(:position) }, source: :variant_image_images, through: :variants_including_master
-
   def variant_images
-    nonuniq_variant_images.distinct
+    Spree::Image
+      .joins(:variant_images).references(:variant_images)
+      .where(spree_assets_variants: { variant_id: variant_ids})
   end
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,5 +1,9 @@
 Spree::Variant.class_eval do
-  has_many :variant_images, -> { order(:position) }, class_name: '::Spree::VariantImage'
+  has_many :variant_images, -> (object) {
+    master = object.is_a?(Spree::Variant) ? object.product.master : object.master
+    variant_ids = [object.id, master.id].uniq
+    unscope(:where).where(variant_id: variant_ids).order(:variant_id, :position)
+  }, class_name: '::Spree::VariantImage'
   has_many :variant_image_images, through: :variant_images, source: :image
 
   alias_method :images, :variant_image_images

--- a/app/models/spree/variant_image.rb
+++ b/app/models/spree/variant_image.rb
@@ -7,6 +7,7 @@ module Spree
     scope :with_position, -> { where("position IS NOT NULL") }
     default_scope -> { order("#{self.table_name}.position") }
 
+    validates_presence_of :image_id, :variant_id
     # on create only just in case there are some lingering in the system
     validates_uniqueness_of :image_id, scope: :variant_id, on: :create
   end

--- a/spec/models/spree/image_decorator_spec.rb
+++ b/spec/models/spree/image_decorator_spec.rb
@@ -20,4 +20,11 @@ describe Spree::Image do
       expect(image.variants.size).to eq(2)
     end
   end
+
+  it 'validates variant association when told to do so' do
+    image.variants = []
+    image.validate_variant_presence = true
+    image.save
+    expect(image.valid?).to be_falsy
+  end
 end

--- a/spec/models/spree/product_decorator_spec.rb
+++ b/spec/models/spree/product_decorator_spec.rb
@@ -3,19 +3,20 @@ require 'spec_helper'
 describe Spree::Product do
   let(:product) { create :product }
   let(:variant) { create :base_variant, product: product }
-  let(:image_green) { create :image, viewable_type: 'Spree::Variant' }
-  let(:image_blue) { create :image, viewable_type: 'Spree::Variant' }
+  let(:image_green) { create :image }
+  let(:image_blue) { create :image }
 
   before do
-    variant.images << image_green
-    variant.images << image_blue
-    variant.save
+    Spree::VariantImage.create!(variant: variant, image: image_green)
+    Spree::VariantImage.create!(variant: variant, image: image_blue)
+    variant.reload
+    product.reload
   end
 
   describe '#variant_images' do
     it 'returns unique list of variant images' do
-      expect(product.reload.variant_images.size).to eq(2)
-      expect(product.reload.variant_images).to include(image_blue, image_green)
+      expect(product.variant_images.size).to eq(2)
+      expect(product.variant_images).to include(image_blue, image_green)
     end
   end
 

--- a/spec/models/spree/variant_decorator_spec.rb
+++ b/spec/models/spree/variant_decorator_spec.rb
@@ -6,8 +6,11 @@ describe Spree::Variant do
   let(:image_blue) { create :image }
 
   before do
-    variant.images << image_green
-    variant.images << image_blue
+    Spree::VariantImage.create!(variant: variant, image: image_green)
+    Spree::VariantImage.create!(variant: variant, image: image_blue)
+    variant.reload
+    # variant.images << image_green
+    # variant.images << image_blue
   end
 
   describe 'variant relationship' do
@@ -26,6 +29,7 @@ describe Spree::Variant do
 
       variant.variant_images.where(image: image_blue).first.update_attributes(position: 1)
       variant.variant_images.where(image: image_green).first.update_attributes(position: 0)
+      variant.reload
 
       expect(variant.images.first).to eq image_green
       expect(variant.images.last).to eq image_blue
@@ -33,6 +37,26 @@ describe Spree::Variant do
   end
 
   it "cannot associate itself to the same image twice" do
-    expect { variant.images << image_green }.to raise_error ActiveRecord::RecordInvalid, /Image has already been taken/
+    expect {
+      Spree::VariantImage.create!(variant: variant, image: image_green)
+    }.to raise_error ActiveRecord::RecordInvalid, /Image has already been taken/
+  end
+
+  describe '#images' do
+    subject { variant.images }
+
+    context 'when master variant has images' do
+      let(:product) { variant.product }
+      let(:master_variant) { product.master }
+      let(:image_red) { create :image }
+
+      before do
+        master_variant.images << image_red
+      end
+
+      it 'should include master variant images' do
+        expect(variant.images.size).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
@WIP

Fixes issue 1 in the first commit

The second commit is an attempt at bringing in master variant images. It's failing 2 specs, one of which is because the object passed to the has_many proc is a Product in that test.

