### PR TITLE
Add Variant#display_images

### DIFF
--- a/app/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/controllers/spree/admin/images_controller_decorator.rb
@@ -10,6 +10,7 @@ Spree::Admin::ImagesController.class_eval do
     end
 
     def set_variants
+      @image.validate_variant_presence = true
       @image.variant_ids = viewable_ids
     end
 

--- a/app/models/spree/image_decorator.rb
+++ b/app/models/spree/image_decorator.rb
@@ -1,12 +1,15 @@
 Spree::Image.class_eval do
-  attr_accessor :viewable_ids
+  attr_accessor :viewable_ids, :validate_variant_presence
 
-  has_many :variant_images, class_name: '::Spree::VariantImage'
+  has_many :variant_images, class_name: '::Spree::VariantImage', dependent: :destroy
   has_many :variants, through: :variant_images
 
   validates :variants,
-    length: { minimum: 1,
-              message: 'must have at least one selection' }
+            length: {
+              minimum: 1,
+              message: 'must have at least one selection',
+              if: -> { validate_variant_presence }
+            }
 
   def variant_html_classes
     variant_ids.map { |variant| "tmb-#{variant}"}.join(" ")

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,7 +1,16 @@
 Spree::Variant.class_eval do
-  has_many :variant_images, -> { order(:position) }, class_name: '::Spree::VariantImage'
+  has_many :variant_images, -> { order(:position) }, class_name: '::Spree::VariantImage', dependent: :destroy
   has_many :variant_image_images, through: :variant_images, source: :image
+
+  has_many :display_variant_images, -> (object) {
+    master = object.product.master
+    variant_ids = [object.id, master.id].uniq
+    unscope(:where).where(variant_id: variant_ids).order(:variant_id, :position)
+  }, class_name: '::Spree::VariantImage'
+
+  has_many :display_images, through: :display_variant_images, source: :image
 
   alias_method :images, :variant_image_images
   alias_method :images=, :variant_image_images=
+
 end

--- a/app/models/spree/variant_image.rb
+++ b/app/models/spree/variant_image.rb
@@ -9,5 +9,6 @@ module Spree
 
     # on create only just in case there are some lingering in the system
     validates_uniqueness_of :image_id, scope: :variant_id, on: :create
+    validates_presence_of :image_id, :variant_id
   end
 end

--- a/spec/models/spree/image_decorator_spec.rb
+++ b/spec/models/spree/image_decorator_spec.rb
@@ -20,4 +20,11 @@ describe Spree::Image do
       expect(image.variants.size).to eq(2)
     end
   end
+
+  it 'validates variant association when told to do so' do
+    image.variants = []
+    image.validate_variant_presence = true
+    image.save
+    expect(image.valid?).to be_falsy
+  end
 end

--- a/spec/models/spree/product_decorator_spec.rb
+++ b/spec/models/spree/product_decorator_spec.rb
@@ -10,12 +10,13 @@ describe Spree::Product do
     variant.images << image_green
     variant.images << image_blue
     variant.save
+    product.reload
   end
 
   describe '#variant_images' do
     it 'returns unique list of variant images' do
-      expect(product.reload.variant_images.size).to eq(2)
-      expect(product.reload.variant_images).to include(image_blue, image_green)
+      expect(product.variant_images.size).to eq(2)
+      expect(product.variant_images).to include(image_blue, image_green)
     end
   end
 

--- a/spec/models/spree/variant_decorator_spec.rb
+++ b/spec/models/spree/variant_decorator_spec.rb
@@ -10,14 +10,12 @@ describe Spree::Variant do
     variant.images << image_blue
   end
 
-  describe 'variant relationship' do
+  describe '#images' do
     it "should have many images" do
       expect(variant.images.size).to eq(2)
     end
-  end
 
-  describe 'images are ordered by variant image positions' do
-    it "returns the images ordered by variant image position" do
+    it 'orders image by variant image position' do
       variant.variant_images.where(image: image_blue).first.update_attributes(position: 0)
       variant.variant_images.where(image: image_green).first.update_attributes(position: 1)
 
@@ -30,9 +28,28 @@ describe Spree::Variant do
       expect(variant.images.first).to eq image_green
       expect(variant.images.last).to eq image_blue
     end
+
+    it 'disallows duplicate associations' do
+      expect { variant.images << image_green }.to raise_error ActiveRecord::RecordInvalid, /Image has already been taken/
+    end
   end
 
-  it "cannot associate itself to the same image twice" do
-    expect { variant.images << image_green }.to raise_error ActiveRecord::RecordInvalid, /Image has already been taken/
+  describe '#display_images' do
+    subject { variant.display_images }
+    context 'when the master variant has images' do
+      let(:product) { variant.product }
+      let(:master_variant) { product.master }
+      let(:image_red) { create :image }
+
+      before do
+        master_variant.images << image_red
+        expect(master_variant.images.size).to eq(1)
+      end
+
+      it 'includes master variant images' do
+        expect(subject.size).to eq(3)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
When displaying Images for a Variant, we want to include Images
associated with the Product's master Variant as well. These Images are
considered applicable to all Variants of the Product. This change allows
us to build that list of Images via arel without disrupting the use of
the #images association.

One other change required here is that in some cases we need to allow
Images to be created without having a Variant associated with them. We
add a validation on VariantImage to prevent invalid join records from
being created.