### PR TITLE
Remove validation on VariantImage for assoc ids

### DIFF
--- a/app/models/spree/variant_image.rb
+++ b/app/models/spree/variant_image.rb
@@ -9,6 +9,5 @@ module Spree
 
     # on create only just in case there are some lingering in the system
     validates_uniqueness_of :image_id, scope: :variant_id, on: :create
-    validates_presence_of :image_id, :variant_id
   end
 end


### PR DESCRIPTION
Both ids need not be present during the validation phase, as they will
be added later in the save process.