### PR TITLE
Remove sql DISTINCT

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -2,6 +2,6 @@ Spree::Product.class_eval do
   has_many :nonuniq_variant_images, -> { order(:position) }, source: :variant_image_images, through: :variants_including_master
 
   def variant_images
-    nonuniq_variant_images.distinct
+    nonuniq_variant_images
   end
 end


### PR DESCRIPTION
In Rails 5.1 using DISTINCT where a lot of ORDER BY clauses are present
seems to cause some confusion in Arel. See

https://github.com/rails/rails/pull/29848

and its references for more context. I don't think there is currently a
case where we would get the same image more than once, as our image
asset management is strictly tied to Product Variants right now.