### PR TITLE
Remove most order() calls

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,7 +1,11 @@
 Spree::Product.class_eval do
-  has_many :nonuniq_variant_images, -> { order(:position) }, source: :variant_image_images, through: :variants_including_master
+  has_many :nonuniq_variant_images, source: :variant_image_images, through: :variants_including_master
 
   def variant_images
     nonuniq_variant_images.distinct
+  end
+
+  def display_image
+    images.first || nonuniq_variant_images.first || Spree::Image.new
   end
 end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,11 +1,11 @@
 Spree::Variant.class_eval do
-  has_many :variant_images, -> { order(:position) }, class_name: '::Spree::VariantImage', dependent: :destroy
+  has_many :variant_images, class_name: '::Spree::VariantImage', dependent: :destroy
   has_many :variant_image_images, through: :variant_images, source: :image
 
   has_many :display_variant_images, -> (object) {
     master = object.product.master
     variant_ids = [object.id, master.id].uniq
-    unscope(:where).where(variant_id: variant_ids).order(:variant_id, :position)
+    unscope(:where).where(variant_id: variant_ids)
   }, class_name: '::Spree::VariantImage'
 
   has_many :display_images, through: :display_variant_images, source: :image

--- a/app/models/spree/variant_image.rb
+++ b/app/models/spree/variant_image.rb
@@ -5,7 +5,6 @@ module Spree
     belongs_to :variant, class_name: 'Spree::Variant', touch: true
 
     scope :with_position, -> { where("position IS NOT NULL") }
-    default_scope -> { order("#{self.table_name}.position") }
 
     # on create only just in case there are some lingering in the system
     validates_uniqueness_of :image_id, scope: :variant_id, on: :create


### PR DESCRIPTION
In Rails 5.1, SQL queries with DISTINCT, COUNT(), and ORDER_BY are not
parsed correctly leading to an error from Postgres. A similar problem
was reported and fixed on

https://github.com/rails/rails/pull/29848

but I don't think it is the same problem as this one.

I prefer to avoid putting ORDER BY clauses into has_many associtainos,
default scopes, & etc. because they inevitably get in the way. By
removing them here, we will probably have to add  them back in a
presenter later. For now it's enough to get them out of the way.