### PR TITLE
Fix undefined method 'variant_ids' for nil:NilClass in Spree::Admin::Images#index

### DIFF
--- a/app/overrides/spree/admin/images/_form/replace_variant_select_with_multi_select.html.erb.deface
+++ b/app/overrides/spree/admin/images/_form/replace_variant_select_with_multi_select.html.erb.deface
@@ -1,6 +1,6 @@
 <!-- replace 'erb[loud]:contains("f.select :viewable_id")' -->
 <%= f.hidden_field :viewable_id, value: 1 %>
-<%= f.select :viewable_ids, options_for_select(@variants, @image.variant_ids), {}, {multiple: true, :class => 'fullwidth'} %>
+<%= f.select :viewable_ids, options_for_select(@variants, f.object.variant_ids), {}, {multiple: true, :class => 'fullwidth'} %>
 
 <%# Keeping this script tag in the view for now.  %>
 <script>


### PR DESCRIPTION
The `@image` instance variable is only present for the new/edit actions, and not for the hidden form rendered on the index page. 

In `index.html.erb`, the hidden form is rendered like this: (in `solidus_backend`)

```erb
<div id="new_image" class="hidden">
  <%= render 'new', product: @product, image: Spree::Image.new(viewable: @product) %>
</div>
```

So there's no `@image` instance variable, but we can get the image from `f.object`.
