### PR TITLE
1 is not a good default for viewable_id

### DIFF
--- a/app/overrides/spree/admin/images/_form/replace_variant_select_with_multi_select.html.erb.deface
+++ b/app/overrides/spree/admin/images/_form/replace_variant_select_with_multi_select.html.erb.deface
@@ -1,5 +1,5 @@
 <!-- replace 'erb[loud]:contains("f.select :viewable_id")' -->
-<%= f.hidden_field :viewable_id, value: 1 %>
+<%= f.hidden_field :viewable_id, value: @variants.first.try(:id) %>
 <%= f.select :viewable_ids, options_for_select(@variants, f.object.variant_ids), {}, {multiple: true, :class => 'fullwidth'} %>
 
 <%# Keeping this script tag in the view for now.  %>


### PR DESCRIPTION
I didn't realize that I needed to click the "+ New Image" button before starting an image upload, so it used the default `viewable_id` of `1`, which raised an error. Better to use the first variant as the default id.