### PR TITLE
Don't check for variants too early

### DIFF
--- a/app/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/controllers/spree/admin/images_controller_decorator.rb
@@ -10,7 +10,7 @@ Spree::Admin::ImagesController.class_eval do
     end
 
     def set_variants
-      @image.validate_variant_presence = true
+      @image.validate_variant_presence = false
       @image.variant_ids = viewable_ids
     end
 


### PR DESCRIPTION
This check seems to be set a bit too early, so the form always gives an
error that no variants have been selected and it hides the variant
selection apparatus.