### PR TITLE
Set default variant_ids to master id

### DIFF
--- a/app/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/controllers/spree/admin/images_controller_decorator.rb
@@ -6,7 +6,7 @@ Spree::Admin::ImagesController.class_eval do
   private
 
     def set_default_variants
-      @image.variant_ids = [@product.id]
+      @image.variant_ids = [@product.master.id]
     end
 
     def set_variants
@@ -25,5 +25,10 @@ Spree::Admin::ImagesController.class_eval do
       end
 
       params[:image][:viewable_ids] = Array(params[:image][:viewable_ids]).reject(&:blank?)
+
+      # fallback to the master variant
+      unless params[:image][:viewable_ids].present?
+        params[:image][:viewable_ids] = [@product.master.id]
+      end
     end
 end

--- a/spec/controllers/spree/admin/images_controller_spec.rb
+++ b/spec/controllers/spree/admin/images_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+module Spree
+  module Admin
+    RSpec.describe ImagesController, type: :request do
+      stub_authorization!
+
+      describe 'GET #new' do
+        # create a product with >1 variant to de-sync product IDs
+        # from variant IDs
+        let!(:preexisting_variant) { create(:variant) }
+        let!(:product) { create(:product) }
+        let(:master) { product.master }
+
+        it 'defaults images to the master variant' do
+          expect(product.id).to_not eq(master.id)
+          get "/admin/products/#{product.id}/images/new"
+          expect(assigns(:image).variant_ids).to include(master.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/solidus.rb
+++ b/spec/support/solidus.rb
@@ -1,0 +1,1 @@
+require 'spree/testing_support/authorization_helpers'


### PR DESCRIPTION
When attaching an image to a product, we need to default to attaching it
to the product's master variant. It makes no sense to add the product's
ID as a variant_id.

This is very much a WIP as I don't know if this change is sufficient to fix the problem I'm aiming at. That problem is "when I upload a new product image, if I take no other action the image is uploaded but not associated with any of the product's variants and thus disappears from the product images page."