### PR TITLE
Return correct params to variant ids

### DIFF
--- a/app/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/controllers/spree/admin/images_controller_decorator.rb
@@ -20,15 +20,21 @@ Spree::Admin::ImagesController.class_eval do
       # This allows the existing drag / drop image upload form to continue to
       # function with no additional modifications
       #
-      if params[:image][:viewable_ids].nil? && params[:image][:viewable_id].present?
-        params[:image][:viewable_ids] = [params[:image][:viewable_id]]
-      end
+      viewable_ids = if params[:image][:viewable_ids].present?
+                       params[:image][:viewable_ids]
+                     elsif params[:image][:viewable_id].present?
+                       [params[:image][:viewable_id]]
+                     end
 
-      params[:image][:viewable_ids] = Array(params[:image][:viewable_ids]).reject(&:blank?)
+      # Drop nil / empty string values
+      viewable_ids = Array(viewable_ids).reject(&:blank?)
 
       # fallback to the master variant
-      unless params[:image][:viewable_ids].present?
-        params[:image][:viewable_ids] = [@product.master.id]
+      unless viewable_ids.present?
+        viewable_ids = [@product.master.id]
       end
+
+      # return value to ensure assignment inside set_variants
+      viewable_ids
     end
 end

--- a/spec/controllers/spree/admin/images_controller_spec.rb
+++ b/spec/controllers/spree/admin/images_controller_spec.rb
@@ -18,6 +18,36 @@ module Spree
           expect(assigns(:image).variant_ids).to include(master.id)
         end
       end
+
+      describe 'POST #create' do
+        let(:variant) { create(:variant) }
+        let(:product) { variant.product }
+
+        let(:create_path) {
+          "/admin/products/#{product.id}/images"
+        }
+        let(:create_params) {
+          {
+            image: {
+              viewable_ids: [variant.id],
+            },
+          }
+        }
+
+        around(:each) do |example|
+          prev_value = ActionController::Base.allow_forgery_protection
+          ActionController::Base.allow_forgery_protection = false
+          example.run
+          ActionController::Base.allow_forgery_protection = prev_value
+        end
+
+        it 'sets the viewable IDs to the passed parameters' do
+          post create_path, params: create_params
+          expect(assigns(:image).viewable_ids).to eq([variant.id.to_s])
+
+        end
+
+      end
     end
   end
 end


### PR DESCRIPTION
Add an additional line returning the viewable_ids to ensure assignment
to @image instance var.