### PR TITLE
Support solidus v2.8 gallery interface

### DIFF
--- a/app/models/spree/gallery/variant_gallery_decorator.rb
+++ b/app/models/spree/gallery/variant_gallery_decorator.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Gallery
+    module VariantGalleryDecorator
+      def images
+        @images ||= @variant.display_images
+      end
+
+      Spree::Gallery::VariantGallery.prepend(self)
+    end
+  end
+end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -6,6 +6,6 @@ Spree::Product.class_eval do
   end
 
   def display_image
-    variant_images.first || images.first || Spree::Image.new
+    gallery.images.first
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -6,6 +6,6 @@ Spree::Product.class_eval do
   end
 
   def display_image
-    gallery.images.first
+    gallery.images.first || Spree::Image.new
   end
 end

--- a/app/models/spree/variant_gallery_decorator.rb
+++ b/app/models/spree/variant_gallery_decorator.rb
@@ -1,9 +1,0 @@
-module Spree
-  module VariantGalleryDecorator
-    def images
-      @images ||= @variant.display_images
-    end
-
-    Spree::VariantGallery.prepend(self)
-  end
-end

--- a/app/models/spree/variant_gallery_decorator.rb
+++ b/app/models/spree/variant_gallery_decorator.rb
@@ -1,0 +1,9 @@
+module Spree
+  module VariantGalleryDecorator
+    def images
+      @images ||= @variant.display_images
+    end
+
+    Spree::VariantGallery.prepend(self)
+  end
+end


### PR DESCRIPTION
In Solidus v2.8, the team introduced a new `gallery` interface for
images on products and variants (see
https://github.com/solidusio/solidus/pull/2337/files). This will allow
the eventual replacement of `paperclip` with a modern and maintained
image management library.

This commit should support the gallery interface while continuing to
support the old `display_image` access method as well.